### PR TITLE
Sheet save format doc version sync

### DIFF
--- a/socialcalc-3.js
+++ b/socialcalc-3.js
@@ -370,7 +370,7 @@ SocialCalc.Sheet.prototype.RecalcSheet = function() {return SocialCalc.RecalcShe
 //
 // Linetypes are:
 //
-//    version:versionname - version of this format. Currently 1.4.
+//    version:versionname - version of this format. Currently 1.5.
 //
 //    cell:coord:type:value...:type:value... - Types are as follows:
 //


### PR DESCRIPTION
According to the [code on line 785](https://github.com/marcelklehr/socialcalc/blob/0e912b2a0d3866824d1503ebb83be0b08400f557/socialcalc-3.js#L785), the version of the sheet save format is 1.5 but the [comment on line 373 claims 1.4](https://github.com/marcelklehr/socialcalc/blob/0e912b2a0d3866824d1503ebb83be0b08400f557/socialcalc-3.js#L373). This PR puts the latter in sync with the former to avoid confusion.
