### PR TITLE
added feature - Ctrl+A should mark all cells audreyt/ethercalc#368

### DIFF
--- a/SocialCalc.js
+++ b/SocialCalc.js
@@ -7567,6 +7567,11 @@ SocialCalc.TableEditor = function(context) {
       var ta, cell, position, cmd, sel, cliptext;
 
       switch (charname) {
+         case "[ctrl-a]":
+            editor.MoveECell("A1");
+            editor.RangeAnchor("A1");
+            editor.RangeExtend(SocialCalc.crToCoord(editor.context.sheetobj.attribs.lastcol,editor.context.sheetobj.attribs.lastrow));
+            return false;      
          case "[ctrl-c]":
          case "[ctrl-x]":
             ta = editor.pasteTextarea;
@@ -13805,6 +13810,7 @@ SocialCalc.keyboardTables = {
       },
 
    controlKeysIE: {
+      65: "[ctrl-a]",
       67: "[ctrl-c]",
       83: "[ctrl-s]",
       86: "[ctrl-v]",
@@ -13821,6 +13827,7 @@ SocialCalc.keyboardTables = {
       },
 
    controlKeysOpera: {
+      65: "[ctrl-a]",
       67: "[ctrl-c]",
       83: "[ctrl-s]",
       86: "[ctrl-v]",
@@ -13835,6 +13842,7 @@ SocialCalc.keyboardTables = {
       },
 
    controlKeysSafari: {
+      97: "[ctrl-a]",
       99: "[ctrl-c]",
       115: "[ctrl-s]",
       118: "[ctrl-v]",
@@ -13854,6 +13862,7 @@ SocialCalc.keyboardTables = {
       },
 
    controlKeysFirefox: {
+      97: "[ctrl-a]",
       99: "[ctrl-c]",
       115: "[ctrl-s]",
       118: "[ctrl-v]",

--- a/socialcalctableeditor.js
+++ b/socialcalctableeditor.js
@@ -188,6 +188,11 @@ SocialCalc.TableEditor = function(context) {
       var ta, cell, position, cmd, sel, cliptext;
 
       switch (charname) {
+         case "[ctrl-a]":
+            editor.MoveECell("A1");
+            editor.RangeAnchor("A1");
+            editor.RangeExtend(SocialCalc.crToCoord(editor.context.sheetobj.attribs.lastcol,editor.context.sheetobj.attribs.lastrow));
+            return false;      
          case "[ctrl-c]":
          case "[ctrl-x]":
             ta = editor.pasteTextarea;
@@ -6426,6 +6431,7 @@ SocialCalc.keyboardTables = {
       },
 
    controlKeysIE: {
+      65: "[ctrl-a]",
       67: "[ctrl-c]",
       83: "[ctrl-s]",
       86: "[ctrl-v]",
@@ -6442,6 +6448,7 @@ SocialCalc.keyboardTables = {
       },
 
    controlKeysOpera: {
+      65: "[ctrl-a]",
       67: "[ctrl-c]",
       83: "[ctrl-s]",
       86: "[ctrl-v]",
@@ -6456,6 +6463,7 @@ SocialCalc.keyboardTables = {
       },
 
    controlKeysSafari: {
+      97: "[ctrl-a]",
       99: "[ctrl-c]",
       115: "[ctrl-s]",
       118: "[ctrl-v]",
@@ -6475,6 +6483,7 @@ SocialCalc.keyboardTables = {
       },
 
    controlKeysFirefox: {
+      97: "[ctrl-a]",
       99: "[ctrl-c]",
       115: "[ctrl-s]",
       118: "[ctrl-v]",


### PR DESCRIPTION
Testing:
 sheet with values - ctrl+a then ctrl+c then move to empty cell, then ctrl+v
 test scroll - scrolls to A1 with large sheet
 test small sheet


Signed-off-by: Eddy Parkinson