### PR TITLE
Modify drag'n fill command behaviour to fix audreyt/ethercalc#769.

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -26,10 +26,10 @@ var css_files = [
     css_folder + 'socialcalc.css'
 ];
 
-gulp.task('validate-js', function () {
+function validate_js() {
     for (js_file of filesExist(js_files)) {
         gulp.src(js_file)
-            .pipe(jshint())
+            .pipe(jshint({"asi": true, "maxerr": 222}))
             .pipe(jshint.reporter('jshint-stylish'));
     }
 
@@ -39,20 +39,20 @@ gulp.task('validate-js', function () {
         .pipe(concat('module-wrapper.js'))
         .pipe(jshint())
         .pipe(jshint.reporter('jshint-stylish'));
-});
+};
 
-gulp.task('js', ['validate-js'], function () {
+function make_js() {
     var files = filesExist([].concat(js_top_file, js_files, js_bottom_file));
     return gulp.src(files)
         .pipe(concat('SocialCalc.js'))
         .pipe(gulp.dest(dist_folder));
-});
+};
 
-gulp.task('css', function () {
+function make_css() {
     var files = filesExist(css_files);
     return gulp.src(files)
         .pipe(concat('socialcalc.css'))
         .pipe(gulp.dest(dist_folder));
-});
+};
 
-gulp.task('default', ['js', 'css'], function () {});
+exports.default = gulp.series(validate_js, make_js, make_css);

--- a/js/socialcalc-3.js
+++ b/js/socialcalc-3.js
@@ -2181,46 +2181,18 @@ SocialCalc.ExecuteSheetCommand = function(sheet, cmd, saveundo) {
          sheet.changedrendervalues = true;
          if (saveundo) changes.AddUndo("changedrendervalues"); // to take care of undone pasted spans
          what = cmd.NextToken();
+         var inc = cmd.NextToken();
          rest = cmd.RestOfString();
          ParseRange();
-         function increment_amount(down) {
-            function valid_datatype(type) {
-		return type == "v" || type == "c";
-            }
-            var editor = SocialCalc.GetSpreadsheetControlObject().editor;
-            var range = editor.range2;
-            var returnval = undefined;
-            if (range.hasrange) {
-                var startcell, endcell;
-                if (down && (range.bottom - range.top == 1) && range.left == range.right) {
-                  startcell = sheet.GetAssuredCell(SocialCalc.crToCoord(range.left, range.top));
-                  endcell = sheet.GetAssuredCell(SocialCalc.crToCoord(range.left, range.bottom));
-                  if (valid_datatype(startcell.datatype) && valid_datatype(endcell.datatype)) {
-                      returnval =  endcell.datavalue - startcell.datavalue;
-                  }
-                } else if (!down && range.left != range.right) {
-                  startcell = sheet.GetAssuredCell(SocialCalc.crToCoord(range.left, range.top));
-                  endcell = sheet.GetAssuredCell(SocialCalc.crToCoord(range.right, range.top));
-                  if (valid_datatype(startcell.datatype) && valid_datatype(endcell.datatype)) {
-                      returnval =  endcell.datavalue - startcell.datavalue;
-		  }
-                }
-            }
-           editor.Range2Remove();
-           return returnval;
-         }
-	 var inc;
          if (cmd1 == "fillright") {
             fillright = true;
             rowstart = cr1.row;
             colstart = cr1.col + 1;
-	    inc = increment_amount(false);
             }
          else {
             fillright = false;
             rowstart = cr1.row + 1;
             colstart = cr1.col;
-	    inc = increment_amount(true);
             }
          for (row = rowstart; row <= cr2.row; row++) {
             for (col = colstart; col <= cr2.col; col++) {

--- a/js/socialcalctableeditor.js
+++ b/js/socialcalctableeditor.js
@@ -4876,30 +4876,33 @@ SocialCalc.CellHandlesMouseUp = function(e) {
       case "Fill":
       case "FillC":
 
-         crstart = SocialCalc.coordToCr(cellhandles.startingcoord);
-         crend = SocialCalc.coordToCr(result.coord);
-         if (cellhandles.filltype) {
-            if (cellhandles.filltype=="Down") {
-               crend.col = crstart.col;
+         var increment = 0;
+         if ( (editor.range2.left != editor.range2.right) || (editor.range2.top != editor.range2.bottom) ) {
+           var sheet = editor.context.sheetobj;
+           var startCell = sheet.GetAssuredCell(SocialCalc.crToCoord(editor.range.left, editor.range.top));
+           var endCell = startCell;
+           if (cellhandles.filltype) {
+             if (cellhandles.filltype=="Down") {
+               endCell = sheet.GetAssuredCell(SocialCalc.crToCoord(editor.range.left, editor.range.top+1));
                }
-            else {
-               crend.row = crstart.row;
+             else if (cellhandles.filltype=="Right") {
+               endCell = sheet.GetAssuredCell(SocialCalc.crToCoord(editor.range.left+1, editor.range.top));
                }
-            }
-         result.coord = SocialCalc.crToCoord(crend.col, crend.row);
+             if ( (startCell.datatype == "v" || startCell.datatype == "c")
+               && (endCell.datatype == "v" || endCell.datatype == "c")) {
+                  increment = endCell.datavalue - startCell.datavalue;
+               }
+             }
+           }
+         editor.Range2Remove();
 
-         editor.MoveECell(result.coord);
-         editor.RangeExtend();
-
-         if (editor.cellhandles.filltype=="Right") {
-            cmdtype = "right";
-            }
-         else {
-            cmdtype = "down";
-            }
-         cstr = "fill"+cmdtype+" "+SocialCalc.crToCoord(editor.range.left, editor.range.top)+
-                   ":"+SocialCalc.crToCoord(editor.range.right, editor.range.bottom)+cmdtype2;
-         editor.EditorScheduleSheetCommands(cstr, true, false);
+         commandStr = "fill" + cellhandles.filltype.toLowerCase()
+                      + " " + SocialCalc.crToCoord(editor.range.left, editor.range.top)
+                      + ":" + SocialCalc.crToCoord(editor.range.right, editor.range.bottom)
+                      + " " + increment
+                      + cmdtype2;
+         editor.EditorScheduleSheetCommands(commandStr, true, false);
+         
          break;
 
       case "Move":

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   },
   "homepage": "https://github.com/marcelklehr/socialcalc#readme",
   "devDependencies": {
-    "gulp": "^3.9.1",
-    "gulp-jshint": "^2.0.4",
-    "jshint": "^2.9.5",
-    "jshint-stylish": "^2.2.1",
-    "gulp-uglify": "^3.0.0",
-    "gulp-concat": "^2.6.1",
-    "files-exist": "^1.0.2"
+    "files-exist": "1.0.2",
+    "gulp": "4.0.2",
+    "gulp-concat": "2.6.1",
+    "gulp-jshint": "2.0.4",
+    "gulp-uglify": "3.0.0",
+    "jshint": "2.9.5",
+    "jshint-stylish": "2.2.1"
   }
 }


### PR DESCRIPTION
Hello,
With this pull request I address two points :
### Drag'n fill
I think I fix this issue : audreyt/ethercalc#769 by modifying the fillright and filldown command string to embed the increment amount.
My tests consists of running an ethercalc instance and using the fill command in all directions with one, two or more cells first selected.
It seems to me that this is good.
### Gulp
I also update gulp package from 3 to 4, to use with newer nodejs.
So I had to adapt gulp.js.
This don't resolve the large warning flow nor the error as on master branch.



